### PR TITLE
added source vs activate language

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ conda env create -f environment.yml
 ## Build virtual environment with all packages installed using conda
 
 conda activate DeepPurpose
-## Activate conda environment
+## Activate conda environment (use "source activate DeepPurpose" for anaconda 4.4 or earlier) 
 
 jupyter notebook
 ## open the jupyter notebook with the conda env


### PR DESCRIPTION
Kexin,

Can you take a look at this change?  This is a small correction to the installation instruction which allows for older version of anaconda which require "source activate" rather than "conda activate"