### PR TITLE
Mod: fix importing bugs

### DIFF
--- a/DeepPurpose/models.py
+++ b/DeepPurpose/models.py
@@ -529,8 +529,8 @@ class DBTA:
 		else:
 			raise AttributeError('Please use one of the available encoding method.')
 
-		if target_encoding == 'AAC' or target_encoding == 'PseudoAAC' or 
-		   target_encoding == 'Conjoint_triad' or target_encoding == 'Quasi-seq':
+		if (target_encoding == 'AAC' or target_encoding == 'PseudoAAC' or 
+		   	target_encoding == 'Conjoint_triad' or target_encoding == 'Quasi-seq'):
 			self.model_protein = MLP(config['input_dim_protein'], config['hidden_dim_protein'], config['mlp_hidden_dims_target'])
 		elif target_encoding == 'CNN':
 			self.model_protein = CNN('protein', **config)
@@ -594,8 +594,8 @@ class DBTA:
 		else:
 			if repurposing_mode:
 				return y_pred
-			return mean_squared_error(y_label, y_pred), pearsonr(y_label, y_pred)[0], 
-				   pearsonr(y_label, y_pred)[1], concordance_index(y_label, y_pred), y_pred
+			return (mean_squared_error(y_label, y_pred), pearsonr(y_label, y_pred)[0], 
+				   	pearsonr(y_label, y_pred)[1], concordance_index(y_label, y_pred), y_pred)
 
 	def train(self, train, val, test = None, verbose = True):
 		if len(train.Label.unique()) == 2:


### PR DESCRIPTION
## Fixed small bugs when I do importing under Python 3.7.7 env

Here is the previous output from Python command line: 
```python
>>> from DeepPurpose import models
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ari/miniconda2/envs/DeepPurpose/DeepPurpose/models.py", line 532
    if target_encoding == 'AAC' or target_encoding == 'PseudoAAC' or 
                                                                    ^
SyntaxError: invalid syntax

  File "/Users/ari/miniconda2/envs/DeepPurpose/DeepPurpose/models.py", line 597
    pearsonr(y_label, y_pred)[1], concordance_index(y_label, y_pred), y_pred

IndentationError: unexpected indent
```
It is resulted from that the line joining fails due to the lack of '\'(explicit) or 'bracket'(implicit)

**The problem are fixed by adding a pair of square brackets, see more at** [Implicit line joining](https://docs.python.org/2/reference/lexical_analysis.html#implicit-line-joining).