### PR TITLE
updated instructions for download & install

### DIFF
--- a/docs/source/notes/download.rst
+++ b/docs/source/notes/download.rst
@@ -8,7 +8,7 @@ Download Code
 
 .. code-block:: bash
 
-   $ git clone git@github.com:kexinhuang12345/DeepPurpose.git
+   $ git clone https://github.com/kexinhuang12345/DeepPurpose.git
    $ ###  Download code repository 
    $
    $
@@ -21,7 +21,7 @@ First time usage: setup conda environment
 
 .. code-block:: bash
 
-   $ conda env create -f env.yml  
+   $ conda env create -f environment.yml  
    $ ## Build virtual environment with all packages installed using conda
    $ 
    $ conda activate DeepPurpose


### PR DESCRIPTION
1. Cloned with https instead of ssh (https://docs.github.com/en/github/using-git/which-remote-url-should-i-use)

2. Updated environment name.