### PR TITLE
solved diving by zero bug

### DIFF
--- a/DeepPurpose/utils.py
+++ b/DeepPurpose/utils.py
@@ -858,7 +858,10 @@ def convert_y_unit(y, from_, to_):
 		y = 10**(-y) / 1e-9
 
 	if to_ == 'p':
-		y = -np.log10(y*1e-9)
+		if y == 0:
+			y = -np.log10(10**-10)
+		else:
+			y = -np.log10(y*1e-9)
 	elif to_ == 'nM':
 		y = y
 


### PR DESCRIPTION
Hi Kexin,

I think the reason why you assigned y = y = -np.log10(y*1e-9 + 1e-10) is to avoid dividing by zero. But I proposed a more reasonable solution for this:
```
def convert_y_unit(y, from_, to_):
	# basis as nM

	if from_ == 'nM':
		y = y
	elif from_ == 'p':
		y = 10**(-y) / 1e-9

	if to_ == 'p':
                if y == 0:
                                y = -np.log10(1e-10)
                else:
		                y = -np.log10(y*1e-9)
	elif to_ == 'nM':
		y = y

	return y
```

In this case, 
```
convert_y_unit(convert_y_unit(100, 'nM', 'p'), 'p', 'nM') 
convert_y_unit(convert_y_unit(100, 'p', 'nM'), 'nM', 'p')
convert_y_unit(convert_y_unit(0, 'p', 'nM'), 'nM', 'p')
convert_y_unit(convert_y_unit(0, 'nM', 'p'), 'p', 'nM')
```
gives you :
```
99.99999999999999
100.0
4.821637332766436e-17
0.09999999999999999
```