### PR TITLE
Improve bindingDB processing functions

### DIFF
--- a/DeepPurpose/dataset.py
+++ b/DeepPurpose/dataset.py
@@ -193,66 +193,121 @@ def download_DrugTargetCommons(path):
 	path = path + '/DtcDrugTargetInteractions.csv'
 	return path
 
-
-def process_BindingDB(path = None, df = None, y = 'Kd', binary = False, convert_to_log = True, threshold = 30):
-	if not os.path.exists(path):
-	    os.makedirs(path)
+def process_BindingDB(path = None, df = None, y = 'Kd', binary = False, \
+					convert_to_log = True, threshold = 30, return_ids = False, \
+					ids_condition = 'OR', harmonize_affinities = None):
+	"""
+	:path: path to original BindingDB CSV/TSV data file. If None, then 'df' is expected.
+	:param df: pre-loaded DataFrame
+	:param y: type of binding affinity label. can be either 'Kd', 'IC50', 'EC50', 'Ki',
+				or a list of strings with multiple choices.
+	:param binary: whether to use binary labels
+	:param convert_to_log: whether to convert nM units to P (log)
+	:param threshold: threshold affinity for binary labels. can be a number or list
+				of two numbers (low and high threshold)
+	:param return_ids: whether to return drug and target ids
+	:param ids_condition: keep samples for which drug AND/OR target IDs exist
+	:param harmonize_affinities:  unify duplicate samples
+							'max' for choosing the instance with maximum affinity
+							'mean' for using the mean affinity of all duplicate instances
+							None to do nothing
+	"""	
+	if path is not None and not os.path.exists(path):
+		os.makedirs(path)
 
 	if df is not None:
 		print('Loading Dataset from the pandas input...')
-	else:
+	elif path is not None:
 		print('Loading Dataset from path...')
 		df = pd.read_csv(path, sep = '\t', error_bad_lines=False)
+	else:
+		ValueError("Either 'df' of 'path' must be provided")
+
 	print('Beginning Processing...')
 	df = df[df['Number of Protein Chains in Target (>1 implies a multichain complex)'] == 1.0]
 	df = df[df['Ligand SMILES'].notnull()]
 
-	if y == 'Kd':
-		idx_str = 'Kd (nM)'
-	elif y == 'IC50':
-		idx_str = 'IC50 (nM)'
-	elif y == 'Ki':
-		idx_str = 'Ki (nM)'
-	elif y == 'EC50':
-		idx_str = 'EC50 (nM)'
-	else:
-		print('select Kd, Ki, IC50 or EC50')
-
-	df_want = df[df[idx_str].notnull()]
+	idx_str = []
+	yy = y
+	if isinstance(y, str):
+		yy = [y]
+	for y in yy:
+		if y == 'Kd':
+			idx_str.append('Kd (nM)')
+		elif y == 'IC50':
+			idx_str.append('IC50 (nM)')
+		elif y == 'Ki':
+			idx_str.append('Ki (nM)')
+		elif y == 'EC50':
+			idx_str.append('EC50 (nM)')
+		else:
+			print('select Kd, Ki, IC50 or EC50')
+	
+	if len(idx_str)==1:
+		df_want = df[df[idx_str[0]].notnull()]
+	else: # select multiple affinity measurements.                 
+		# keep rows for which at least one of the columns in the idx_str list is not null
+		df_want = df.dropna(thresh=1, subset=idx_str) 
+		
 	df_want = df_want[['BindingDB Reactant_set_id', 'Ligand InChI', 'Ligand SMILES',\
-					  'PubChem CID', 'UniProt (SwissProt) Primary ID of Target Chain',\
-					  'BindingDB Target Chain  Sequence', idx_str]]
+					'PubChem CID', 'UniProt (SwissProt) Primary ID of Target Chain',\
+					'BindingDB Target Chain  Sequence'] + idx_str]
+	
+	for y in idx_str:
+		df_want[y] = df_want[y].str.replace('>', '')
+		df_want[y] = df_want[y].str.replace('<', '')
+		df_want[y] = df_want[y].astype(float)
+	
+	# Harmonize into single label using the mean of existing labels:
+	df_want['Label'] = df_want[idx_str].mean(axis=1, skipna=True)
+
 	df_want.rename(columns={'BindingDB Reactant_set_id':'ID',
 							'Ligand SMILES':'SMILES',
 							'Ligand InChI':'InChI',
 							'PubChem CID':'PubChem_ID',
 							'UniProt (SwissProt) Primary ID of Target Chain':'UniProt_ID',
-							'BindingDB Target Chain  Sequence': 'Target Sequence',
-							idx_str: 'Label'},
+							'BindingDB Target Chain  Sequence': 'Target Sequence'},
 							inplace=True)
 
-	df_want['Label'] = df_want['Label'].str.replace('>', '')
-	df_want['Label'] = df_want['Label'].str.replace('<', '')
-	df_want['Label'] = df_want['Label'].astype(float)
-
 	# have at least uniprot or pubchem ID
-	df_want = df_want[df_want.PubChem_ID.notnull() | df_want.UniProt_ID.notnull()]
+	if ids_condition == 'OR':
+		df_want = df_want[df_want.PubChem_ID.notnull() | df_want.UniProt_ID.notnull()]
+	elif ids_condition == 'AND':
+		df_want = df_want[df_want.PubChem_ID.notnull() & df_want.UniProt_ID.notnull()]
+	else:
+		ValueError("ids_condition must be set to 'OR' or 'AND'")
+
 	df_want = df_want[df_want.InChI.notnull()]
 
 	df_want = df_want[df_want.Label <= 10000000.0]
 	print('There are ' + str(len(df_want)) + ' drug target pairs.')
 
+	if harmonize_affinities is not None:
+		df_want = df_want[['PubChem_ID', 'SMILES', 'UniProt_ID', 'Target Sequence', 'Label']]
+		if harmonize_affinities.lower() == 'max_affinity':
+			df_want = df_want.groupby(['PubChem_ID', 'SMILES', 'UniProt_ID', 'Target Sequence']).Label.agg(min).reset_index()
+		if harmonize_affinities.lower() == 'mean':
+			df_want = df_want.groupby(['PubChem_ID', 'SMILES', 'UniProt_ID', 'Target Sequence']).Label.agg(np.mean).reset_index()
+	
 	if binary:
 		print('Default binary threshold for the binding affinity scores are 30, you can adjust it by using the "threshold" parameter')
-		y = [1 if i else 0 for i in df_want.Label.values < threshold]
+		if isinstance(threshold, Sequence):
+			# filter samples with affinity values between the thresholds
+			df_want = df_want[(df_want.Label < threshold[0]) | (df_want.Label > threshold[1])]
+		else: # single threshold
+			threshold = [threshold]
+		y = [1 if i else 0 for i in df_want.Label.values < threshold[0]]
 	else:
 		if convert_to_log:
 			print('Default set to logspace (nM -> p) for easier regression')
 			y = convert_y_unit(df_want.Label.values, 'nM', 'p')
 		else:
 			y = df_want.Label.values
-
+		
+	if return_ids:
+		return df_want.SMILES.values, df_want['Target Sequence'].values, np.array(y), df_want['PubChem_ID'].values, df_want['UniProt_ID'].values
 	return df_want.SMILES.values, df_want['Target Sequence'].values, np.array(y)
+
 
 def load_process_DAVIS(path = './data', binary = False, convert_to_log = True, threshold = 30):
 	print('Beginning Processing...')


### PR DESCRIPTION
added the following features:
- support reading more than one type of affinity label, (i.e both Kd and IC50, or all four types)
- support low and high thresholds for binary labeling, rather than just a single one
- support consolidating duplicate samples using mean or maximum affinity
- support returning target and ligand ids in addition to strings and labels (this is useful for interfacing with the Therapeutics Data Commons framework)
- support both 'AND' and 'OR' conditions keeping samples which have ids for targets and/or ligands

The default argument values will keep the function behavior as before. I checked for backward compatibility by running:

`X_drugs, X_targets, y = dataset.process_BindingDB(path = "./data", df = df, y = 'Kd', binary = False, convert_to_log = True, threshold = 30)` 

and made sure that the same results are obtained with the existing and proposed implementations.
