### PR TITLE
Fix download of Binding DB database (#160)

### DIFF
--- a/DeepPurpose/dataset.py
+++ b/DeepPurpose/dataset.py
@@ -5,6 +5,8 @@ from zipfile import ZipFile
 from DeepPurpose.utils import *
 import json
 import os
+import requests
+import re
 
 '''
 Acknowledgement:
@@ -170,8 +172,13 @@ def download_BindingDB(path = './data'):
 	if not os.path.exists(path):
 	    os.makedirs(path)
 
-	url = " https://www.bindingdb.org/rwd/bind/chemsearch/marvin/SDFdownload.jsp?download_file=/bind/downloads/BindingDB_All_2022m7.tsv.zip"	
-	## url = 'https://www.bindingdb.org/bind/downloads/BindingDB_All_2021m11.tsv.zip'
+	try:
+	    url = "https://www.bindingdb.org/bind/downloads/" + [url.split('/')[-1] for url in re.findall(
+		    r'(/rwd/bind/chemsearch/marvin/SDFdownload.jsp\?download_file=/bind/downloads/BindingDB_All_.*?\.tsv\.zip)',
+			requests.get("https://www.bindingdb.org/rwd/bind/chemsearch/marvin/Download.jsp").text)][0]
+	except Exception:
+	    print("Failed to retrieve current URL for BindingDB, falling back on hard-coded URL")
+	    url = "https://www.bindingdb.org/bind/downloads/BindingDB_All_202305.tsv.zip"
 	saved_path = wget.download(url, path)
 
 	print('Beginning to extract zip file...')


### PR DESCRIPTION
Here is a pull request to fix issue #160 from @parthnatekar, who pointed out issues with the function `dataset.download_BindingDB`.

Here is an outline of the fix, which should continue working when BindingDB is updated, provided they do not change the URL format too much:

- Current URL for BindingDB database is malformed and out-of-date
- Replace static URL with requests and re-based parsing of BindingDB download page for current download link (regex to find file like "BindingDB_All_.*?\.tsv\.zip")
- Hard-code up-to-date URL as a backup (https://www.bindingdb.org/bind/downloads/BindingDB_All_202305.tsv.zip)

If you run the following code using the current version of the package:

```python
from DeepPurpose import dataset
dataset.download_BindingDB('./data/')
```

You will get the following error:

```python
Beginning to download dataset...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jprs/Desktop/DeepPurpose/DeepPurpose/dataset.py", line 175, in download_BindingDB
    saved_path = wget.download(url, path)
  File "/home/jprs/Desktop/DeepPurpose/venv/lib/python3.10/site-packages/wget.py", line 526, in download
    (tmpfile, headers) = ulib.urlretrieve(binurl, tmpfile, callback)
  File "/usr/lib/python3.10/urllib/request.py", line 241, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
  File "/usr/lib/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.10/urllib/request.py", line 503, in open
    req = Request(fullurl, data)
  File "/usr/lib/python3.10/urllib/request.py", line 322, in __init__
    self.full_url = url
  File "/usr/lib/python3.10/urllib/request.py", line 348, in full_url
    self._parse()
  File "/usr/lib/python3.10/urllib/request.py", line 377, in _parse
    raise ValueError("unknown url type: %r" % self.full_url)
ValueError: unknown url type: '%20https%3A//www.bindingdb.org/rwd/bind/chemsearch/marvin/SDFdownload.jsp?download_file=/bind/downloads/BindingDB_All_2022m7.tsv.zip'
```

If you install the patched version and re-run the above code, the BindingDB database will download and unzip as expected.